### PR TITLE
define this.request also if auth not set

### DIFF
--- a/gateway.js
+++ b/gateway.js
@@ -61,6 +61,8 @@ function Gateway(log, p_config, index, i_device, i_characteristic, i_value, Char
     }
 
     this.request = request.defaults( { 'auth': auth, 'rejectUnauthorized': false } );
+  } else {
+    this.request = request.defaults();
   }
   
   this.longpoll_running = false;


### PR DESCRIPTION
If not authentication details aren't set, this.request won't be defined. This causes following error:
TypeError: Cannot call method 'get' of undefined at Gateway.<anonymous> (/usr/local/lib/node_modules/homebridge-punt/gateway.js:219:18)
The committed fix makes sure this.request will be defined even without auth details.
